### PR TITLE
add shopware-image tagging for latest mojor version of shopware

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,13 @@ commands:
           command: |
             docker tag dockware/<< parameters.imageName >>:<< parameters.imageTag >> dockware/<< parameters.imageName >>:<< parameters.imageTag >>-<< parameters.imageArch >>
       - run:
+          name: Tag Image for Shopware Major Verion
+          command: | 
+            if [ "<< parameters.imageName >>" = "shopware" -a "<< parameters.imageTag >>" != "dev-main" ]; then
+               docker tag dockware/<< parameters.imageName >>:<< parameters.imageTag >> dockware/<< parameters.imageName >>:$(echo "<< parameters.imageTag >>" | cut -f 1,2 -d '.')-latest
+               docker tag dockware/<< parameters.imageName >>:<< parameters.imageTag >> dockware/<< parameters.imageName >>:$(echo "<< parameters.imageTag >>" | cut -f 1,2 -d '.')-latest-<< parameters.imageArch >>
+            fi
+      - run:
           name: Push Image
           command: |
             docker push dockware/<< parameters.imageName >>:<< parameters.imageTag >>-<< parameters.imageArch >>


### PR DESCRIPTION
I want to purpose a new tag to tag the latest major versions of Shopware.

I think this might be helpful for plugin Developers who want to test their Code always against the newest version but might have to support the old major and have branched codebases there.
This might be not a big Problem now, but for the next major release this might become an issue for some.

In the Workflow in circleCI I added a case for the Shopware and not dev-main images. 
This added a `6.7-latest` and `6.7-latest-<architecture>` tag. I used the first two numbers of the version env for that. 

I have to admit I am new to circleCI and unsure if it works correctly. I tested the code in my shell. 